### PR TITLE
Bugfix in ClouDNS.php - Add Priority for MX-Records

### DIFF
--- a/src/Providers/ClouDNS.php
+++ b/src/Providers/ClouDNS.php
@@ -97,8 +97,9 @@ class ClouDNS implements DnsHostingProviderInterface {
             'host' => $rrsetData['subname'],
             'record-type' => $rrsetData['type'],
             'record' => implode("\n", $rrsetData['records']),
-            'ttl' => $rrsetData['ttl']
-        ]);
+	    'ttl' => $rrsetData['ttl'],
+	    'priority' =>  $rrsetData['priority']
+	]);
         return json_decode($domainName, true);
     }
     
@@ -134,7 +135,8 @@ class ClouDNS implements DnsHostingProviderInterface {
 
         if (!$recordId) {
             throw new Exception("Record not found for modification");
-        }
+	}
+
 
         $response = $this->request('mod-record.json', [
             'domain-name' => $domainName,
@@ -142,7 +144,8 @@ class ClouDNS implements DnsHostingProviderInterface {
             'record-type' => $type,
             'host' => $subname,
             'record' => implode("\n", $rrsetData['records']),
-            'ttl' => $rrsetData['ttl']
+	    'ttl' => $rrsetData['ttl'],
+	    'priority' =>  $rrsetData['priority']
         ]);
         return json_decode($domainName, true);
     }


### PR DESCRIPTION
Priority was not passed for mx records, so they could not be created or updated